### PR TITLE
[COSY] Add http/https CORS origins for both domain and domain:port

### DIFF
--- a/install_cosy.sh
+++ b/install_cosy.sh
@@ -287,10 +287,10 @@ FOOTER_CITY="${FOOTER_CITY:-}"
 
 # Build CORS origin and access URL
 if [[ "$PORT" == "80" ]]; then
-    COSY_CORS_ORIGIN="http://${DOMAIN}"
+    COSY_CORS_ORIGIN="http://${DOMAIN},https://${DOMAIN}"
     ACCESS_URL="http://${DOMAIN}"
 else
-    COSY_CORS_ORIGIN="http://${DOMAIN}:${PORT}"
+    COSY_CORS_ORIGIN="http://${DOMAIN}:${PORT},http://${DOMAIN},https://${DOMAIN}:${PORT},https://${DOMAIN}"
     ACCESS_URL="http://${DOMAIN}:${PORT}"
 fi
 


### PR DESCRIPTION
When a custom port is configured, include all four origin variants: http://{domain}:{port}, http://{domain}, https://{domain}:{port}, https://{domain}. For port 80, include both http and https bare domain origins.