### PR TITLE
automatically set jwt secret on installation

### DIFF
--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       - COSY_FOOTER_STREET=${FOOTER_STREET}
       - COSY_FOOTER_CITY=${FOOTER_CITY}
       - COSY_CORS_ALLOWED_ORIGINS=${COSY_CORS_ALLOWED_ORIGINS}
+      - COSY_JWT_SECRET_KEY=${COSY_JWT_SECRET_KEY}
       - COSY_CUSTOM_METRICS_BASE_URL=http://host.docker.internal:${PORT}
     depends_on:
       database:

--- a/config/k8s/backend/deployment.yaml
+++ b/config/k8s/backend/deployment.yaml
@@ -72,6 +72,11 @@ spec:
                 secretKeyRef:
                   name: cosy-app-secrets
                   key: admin-password
+            - name: COSY_JWT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cosy-app-secrets
+                  key: jwt-secret-key
             - name: COSY_DEFAULTS_INITIALIZE_DUMMY_DATA
               value: "false"
             - name: COSY_CORS_ALLOWED_ORIGINS

--- a/install_cosy.sh
+++ b/install_cosy.sh
@@ -310,6 +310,16 @@ generate_password() {
   printf '%s' "$pw"
 }
 
+generate_jwt_secret() {
+    if command -v openssl &>/dev/null; then
+        openssl rand -base64 32
+    elif command -v base64 &>/dev/null; then
+        head -c 32 /dev/urandom | base64
+    else
+        fatal "Cannot generate JWT secret.\n\n  Install one of: openssl or coreutils (base64)."
+    fi
+}
+
 generate_htpasswd() {
     local user="$1" pass="$2"
     if command -v htpasswd &>/dev/null; then
@@ -334,7 +344,7 @@ ADMIN_PASSWORD="$(generate_password)"
 COSY_INFLUXDB_USERNAME="cosy"
 COSY_INFLUXDB_PASSWORD="$(generate_password)"
 COSY_INFLUXDB_ADMIN_TOKEN="$(generate_password)"
-COSY_JWT_SECRET_KEY="$(head -c 32 /dev/urandom | base64)"
+COSY_JWT_SECRET_KEY="$(generate_jwt_secret)"
 
 # ─────────────────────────────────────────────────────────────────────────────
 #  Normalize installation path (called during deployment)


### PR DESCRIPTION
This pull request adds support for a JWT secret key to the installation and Kubernetes secret management process in `install_cosy.sh`. The key is now generated, passed through environment variables, and included in the Kubernetes secrets.

**JWT Secret Key Support:**

* Added generation of a secure JWT secret key using `urandom` and `base64`, and assigned it to the `COSY_JWT_SECRET_KEY` environment variable.
* Passed the `COSY_JWT_SECRET_KEY` variable into the environment configuration section for use in other scripts or services.
* Included the JWT secret key in the Kubernetes secret creation, ensuring the key is available to deployed services via the `jwt-secret-key` literal.