### PR TITLE
Update version tags for Cosy installation script

### DIFF
--- a/install_cosy.sh
+++ b/install_cosy.sh
@@ -29,9 +29,9 @@ error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 fatal()   { error "$*"; exit 1; }
 
 # ── Constants ────────────────────────────────────────────────────────────────
-COSY_TAG="v1.0.1"
-FRONTEND_TAG="sha-edd9425"
-BACKEND_TAG="sha-c68e624"
+COSY_TAG="v1.0.2"
+FRONTEND_TAG="sha-e62ba91"
+BACKEND_TAG="sha-5ae11f7"
 CONFIG_FILES_URL_PREFIX="https://raw.githubusercontent.com/Magenta-Mause/Cosy/${COSY_TAG}/"
 
 K8S_NAMESPACE="cosy"


### PR DESCRIPTION
This pull request updates the version tags used for deploying Cosy and its components. The main change is bumping the Cosy, frontend, and backend tags to newer versions in the `install_cosy.sh` script.

Version updates:

* Updated `COSY_TAG` to `v1.0.2` to deploy the latest Cosy release.
* Updated `FRONTEND_TAG` to `sha-e62ba91` and `BACKEND_TAG` to `sha-5ae11f7` to use newer builds of the frontend and backend components.