### PR TITLE
Update Discord link and documentation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
     <img src="https://img.shields.io/badge/github-templates--repository-blue?logo=github">
   </a>
   <a href="https://discord.gg/nNtZJnSpSk">
-    <img alt="Discord Server" src="https://img.shields.io/discord/1482365927856017576?logo=discord&label=%20discord&color=5865F2">
+    <img alt="Discord Server" src="https://img.shields.io/discord/1482365926304387196?logo=discord&label=%20discord&color=5865F2">
   </a>
   <a href="https://cosy-hosting.net/">
       <img src="https://img.shields.io/badge/Documentation-F7951D" alt="Documentation" />

--- a/README.md
+++ b/README.md
@@ -22,14 +22,11 @@
   <a href="https://github.com/Magenta-Mause/Cosy-Templates">
     <img src="https://img.shields.io/badge/github-templates--repository-blue?logo=github">
   </a>
-  <a href="https://discord.gg/2uDybryKPe">
-    <img alt="Discord Server" src="https://img.shields.io/discord/1482365926304387196?logo=discord&label=%20discord&color=5865F2">
+  <a href="https://discord.gg/nNtZJnSpSk">
+    <img alt="Discord Server" src="https://img.shields.io/discord/1482365927856017576?logo=discord&label=%20discord&color=5865F2">
   </a>
-  <a href="https://cosy-docs.jannekeipert.de/">
-    <img src="https://img.shields.io/badge/Home%20Page-F7951D" alt="Home Page" />
-  </a>
-  <a href="https://cosy-docs.jannekeipert.de/docs/">
-    <img src="https://img.shields.io/badge/Documentation-F7951D" alt="Documentation" />
+  <a href="https://cosy-hosting.net/">
+      <img src="https://img.shields.io/badge/Documentation-F7951D" alt="Documentation" />
   </a>
   <a href="https://github.com/Magenta-Mause/Cosy-Templates/tree/main/templates">
     <img src="https://img.shields.io/github/directory-file-count/Magenta-Mause/Cosy-Templates/templates?label=Supported%20Games" alt="Supported Games">


### PR DESCRIPTION
This pull request updates the project badges in the `README.md` file to reflect new URLs for the Discord server and documentation. These changes ensure that users are directed to the correct and current resources.

Documentation and community links update:

* Updated the Discord server invite link and badge to point to a new server and server ID.
* Changed the documentation and homepage links: replaced the old homepage link with a new documentation link at `cosy-hosting.net`.

