### PR TITLE
docs: communicate MIT no-warranty / operator-responsibility notice in install scripts

### DIFF
--- a/install_cosy.sh
+++ b/install_cosy.sh
@@ -12,6 +12,16 @@ set -euo pipefail
 #
 # Run './install_cosy.sh <command> --help' for command-specific options.
 # ─────────────────────────────────────────────────────────────────────────────
+# License & liability
+# ─────────────────────────────────────────────────────────────────────────────
+# COSY is free and open-source software licensed under the MIT License and is
+# provided "AS IS", WITHOUT WARRANTY OF ANY KIND. By installing and running it
+# you become the operator of your own instance and are solely responsible for
+# its operation, security, data protection/privacy (e.g. GDPR) and legal
+# compliance. The COSY authors and copyright holders accept no liability for
+# how your instance is run or for any data processed by it.
+# See the LICENSE file for the full terms.
+# ─────────────────────────────────────────────────────────────────────────────
 
 # ── Color & helpers ────────────────────────────────────────────────────────
 RED='\033[0;31m'
@@ -211,6 +221,17 @@ echo "                              ++++++++*****               +++++****       
 echo "                                                                          #=+#++*#                                                                        "
 echo "                                                                          #+#++*#                                                                         "
 echo "                                                                          #*###                                                                           "
+
+# ── License & liability notice (informational, non-blocking) ─────────────────
+echo ""
+echo -e "${BOLD}${YELLOW}── License & liability ──────────────────────────────────────────────${NC}"
+warn "COSY is free/open-source software, MIT-licensed and provided \"AS IS\","
+warn "WITHOUT WARRANTY OF ANY KIND."
+warn "By running it you become the operator of your own instance and are"
+warn "solely responsible for its operation, security, data protection/privacy"
+warn "(e.g. GDPR) and legal compliance — not the COSY authors."
+info "Full terms: see the LICENSE file (https://github.com/Magenta-Mause/Cosy/blob/${COSY_TAG}/LICENSE)."
+echo ""
 
 # ── Interactive prompts (if running in a terminal) ───────────────────────────
 if [[ -t 0 ]] && [[ "${USE_DEFAULTS-}" != "true" ]]; then

--- a/uninstall_cosy.sh
+++ b/uninstall_cosy.sh
@@ -12,6 +12,15 @@ set -euo pipefail
 #
 # Run './uninstall_cosy.sh <command> --help' for command-specific options.
 # ─────────────────────────────────────────────────────────────────────────────
+# License & liability
+# ─────────────────────────────────────────────────────────────────────────────
+# COSY is free and open-source software licensed under the MIT License and is
+# provided "AS IS", WITHOUT WARRANTY OF ANY KIND. As the operator of your own
+# instance you are solely responsible for its operation, security, data
+# protection/privacy (e.g. GDPR) and legal compliance. The COSY authors and
+# copyright holders accept no liability for how your instance is run.
+# See the LICENSE file for the full terms.
+# ─────────────────────────────────────────────────────────────────────────────
 
 # ── Color & helpers ──────────────────────────────────────────────────────────
 RED='\033[0;31m'


### PR DESCRIPTION
## What

Adds a clear MIT license & liability notice to the installation tooling so anyone installing Cosy understands that, under the MIT license, they (the operator) are responsible for operation, data privacy, security and legal compliance of their instance — not the Cosy authors.

## Changes

**Header comment block** (`install_cosy.sh` and `uninstall_cosy.sh`):
- New "License & liability" section stating Cosy is MIT-licensed, provided "AS IS" without warranty of any kind, and that the operator is solely responsible for operation, security, data protection/privacy (e.g. GDPR) and legal compliance. Points to the `LICENSE` file for full terms.

**Runtime disclaimer** (`install_cosy.sh`):
- A short, styled, non-blocking notice printed early in the install flow (after the ASCII banner, before any deployment work begins), using the script's existing `warn()`/`info()` helpers and color style.
- Informational only — no interactive prompt, so non-interactive (`--default`) installs are unaffected.

## Notes

- Wording is kept accurate to the MIT license (no invented legal terms).
- **No deployment logic changed** — this is a docs/notice-only change. `bash -n` passes on both scripts.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)