### PR TITLE
chore: enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/config/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Enables Dependabot for this repository, part of the org-wide rollout tracked in this issue.

## Ecosystems configured
- `docker` (`/config/docker` — from `docker-compose.yml`)

Updates run weekly, are grouped per ecosystem (`patterns: ["*"]`) to reduce PR noise, and are capped at 5 open PRs per ecosystem.

## Handling Dependabot PRs
- Review the grouped update PRs weekly — updates are batched per ecosystem, so expect a single PR per ecosystem rather than many.
- Confirm CI passes on each Dependabot PR before merging.
- Merge patch/minor bumps readily once green.
- Scrutinize major version bumps for breaking changes before merging.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
