### PR TITLE
chore: release v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ When deploying COSY, the installation script configures the application to run w
 *Install Cosy*:
 
 ```bash
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/Magenta-Mause/Cosy/v1.0.1/install_cosy.sh)" _
+sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/Magenta-Mause/Cosy/v1.1.0/install_cosy.sh)" _
 ```
 Note: the `_` can not be removed.
 
 *Uninstall Cosy*:
 
 ```bash
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/Magenta-Mause/Cosy/v1.0.1/uninstall_cosy.sh)" _
+sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/Magenta-Mause/Cosy/v1.1.0/uninstall_cosy.sh)" _
 ```
 Note: the `_` can not be removed.
 

--- a/install_cosy.sh
+++ b/install_cosy.sh
@@ -43,9 +43,9 @@ fatal()   { error "$*"; exit 1; }
 # `BACKEND_TAG=sha-abc123 ./install_cosy.sh docker`) or the corresponding CLI
 # flag (--backend-tag / --frontend-tag / --config-ref). CONFIG_FILES_URL_PREFIX
 # is computed later, after all overrides are resolved.
-: "${COSY_TAG:=v1.0.3}"
-: "${FRONTEND_TAG:=sha-5dba6e8}"
-: "${BACKEND_TAG:=sha-e200a4d}"
+: "${COSY_TAG:=v1.1.0}"
+: "${FRONTEND_TAG:=sha-2659b07}"
+: "${BACKEND_TAG:=sha-ecc4c14}"
 
 K8S_NAMESPACE="cosy"
 INFLUXDB_ORG="cosy-org"


### PR DESCRIPTION
Cuts **v1.1.0**, the first release since v1.0.3 (2026-05-12).

## What this changes

| | v1.0.3 | v1.1.0 |
|---|---|---|
| `COSY_TAG` | `v1.0.3` | `v1.1.0` |
| `BACKEND_TAG` | `sha-e200a4d` | `sha-ecc4c14` |
| `FRONTEND_TAG` | `sha-5dba6e8` | `sha-2659b07` |

Also fixes the README quick-install commands, which still pointed at **v1.0.1** while the current release was v1.0.3 — step 3 of `docs/release-publishing.md` was missed last time.

## Why these images

They are the pair Magenta-Mause already runs in production (`Cosy-Internal-Deployment` auto-deployed both), and they were validated end to end before tagging: a staging systemtest run installed this exact pair on a fresh GitHub runner via `install_cosy.sh` and drove every feature through the real UI — **20 passed, 1 skipped (`rcon`, quarantined), 0 failed** ([run](https://github.com/Magenta-Mause/Cosy-Systemtest/actions/runs/30169159693)).

That run also used `config_ref=main`, so the compose/manifest config this tag will serve was exercised too, not just the images.

## Scope

Three months of work: redesigned server-creation flow, template v3 with host mounts and annotations, a `canCreateGameServers` permission, file editing, **two security fixes** (file-browser symlink escape; write actions gated on `CHANGE_SERVER_FILES`) and **two defects that broke real user paths** — template selection was impossible for the whole v1.0.3 line, and the backend could permanently lose its Docker event stream.

## ⚠️ This release changes the database schema

Cosy now manages its schema with **Flyway** instead of Hibernate `ddl-auto`. On first boot against an existing v1.0.3 database, Flyway baselines it as V1 and applies V2–V4. No manual step is needed, and `V4` backfills any `NULL` `created_on` before adding the constraint.

Two things the changelog calls out explicitly:

- **Baselining does not inspect the schema.** A database that drifted from the stock v1.0.3 shape is stamped as a clean V1 anyway, and later migrations may fail on assumptions that no longer hold.
- **`V3` irreversibly drops orphaned legacy tables and columns.**

Hence: back up before upgrading. Note `install_cosy.sh` has no upgrade command — it installs; existing deployments update by pulling the newly pinned images.

## Follow-ups (not in this PR)

- `Cosy-Docs/src/lib/constants.ts` still says `COSY_VERSION = "v1.0.3"` — separate PR. (`docs/release-publishing.md` steps 4–5 name `Cosy-Landing-Page`, which now redirects to `Cosy-Docs`; the doc should be corrected.)
- `application.yaml:16-22` says `baseline-on-migrate` must be **removed one release after this rollout** — a v1.2.0 task.
- Systemtest suite updates: Magenta-Mause/Cosy-Systemtest#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)