### PR TITLE
chore: add bug/feature issue templates, align with org defaults

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Report a problem so we can fix it
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to Reproduce
+
+<!-- Steps to reproduce the behavior. -->
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. Include error messages and logs if available. -->
+
+## Environment
+
+<!-- Please complete the following information. -->
+
+- **Component:** <!-- e.g. Cosy-Frontend, Cosy-Backend, Cosy-Template-Service, Cosy-Game-Service, Cosy-Minecraft-Integration-Mod, Cosy-Docs -->
+- **Cosy version / commit:** <!-- e.g. v1.0.12 or a commit hash -->
+- **OS:** <!-- e.g. Ubuntu 24.04, Windows 11, macOS 14 -->
+- **Browser (if frontend):** <!-- e.g. Firefox 128, Chrome 126 -->
+- **Deployment:** <!-- e.g. Docker Compose, Kubernetes, local dev -->
+
+## Screenshots / Logs
+
+<!-- Optional: add screenshots or paste relevant log output to help explain the problem. -->
+
+## Additional Context
+
+<!-- Optional: add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/03-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/03-feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement for Cosy
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+
+<!-- A clear and concise description of the feature you'd like to see. -->
+
+## Use Case / Motivation
+
+<!-- What problem does this solve? Who benefits and why is it valuable? -->
+
+## Proposed Solution
+
+<!-- Describe how you imagine this working. -->
+
+## Alternatives Considered
+
+<!-- Optional: describe any alternative solutions or features you've considered. -->
+
+## Additional Context
+
+<!-- Optional: add any other context, mockups, or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true 
+blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussion
     url: https://github.com/magenta-mause/cosy-templates/discussions


### PR DESCRIPTION
## Summary

Cosy has its own `.github/ISSUE_TEMPLATE/` directory (`01-template-request.yaml` + `config.yml`). GitHub applies a repo's local `ISSUE_TEMPLATE` directory *instead of*, not merged with, the org-wide defaults added in [Magenta-Mause/.github#2](https://github.com/Magenta-Mause/.github/pull/2). Net effect: every other Cosy repo's config points bug/feature reports at "the central tracker" (`Magenta-Mause/Cosy`), but Cosy itself only offered "🆕 Template Request" and a blank issue.

## Changes

- Add `.github/ISSUE_TEMPLATE/02-bug_report.md` and `03-feature_request.md` — same content as the org-wide templates, numbered after the existing template-request so it stays first in the chooser.
- Set `blank_issues_enabled: false` in `config.yml`, matching the org default now that real templates exist.
- Left the existing template-request template and the "Questions & Discussion" contact link (→ `cosy-templates/discussions`) untouched — both still make sense for this repo.

## Related issue

Fixes #55